### PR TITLE
Tony/448a_migrate

### DIFF
--- a/lib/src/widgets/solid_file_browser.dart
+++ b/lib/src/widgets/solid_file_browser.dart
@@ -305,8 +305,8 @@ class SolidFileBrowserState extends State<SolidFileBrowser> {
 
   String _getEffectiveFriendlyFolderName() {
     return SolidFileOperations.getFriendlyFolderName(
-        currentPath,
-        widget.basePath,
+      currentPath,
+      widget.basePath,
     );
   }
 

--- a/lib/src/widgets/solid_file_browser.dart
+++ b/lib/src/widgets/solid_file_browser.dart
@@ -32,6 +32,7 @@ import 'package:solidui/src/utils/file_operations.dart';
 import 'package:solidui/src/widgets/solid_file_browser_content.dart';
 import 'package:solidui/src/widgets/solid_file_browser_loading_state.dart';
 import 'package:solidui/src/widgets/solid_file_empty_directory_view.dart';
+import 'package:solidui/src/widgets/solid_file_operations.dart';
 import 'package:solidui/src/widgets/solid_file_path_bar.dart';
 
 /// A file browser widget to interact with files and directories in user's POD.
@@ -265,8 +266,46 @@ class SolidFileBrowserState extends State<SolidFileBrowser> {
   void navigateToPath(String path) {
     setState(() {
       currentPath = path;
+      // Update path history to ensure proper navigation state
+      // If navigating to base path, reset history.
+
+      if (path == widget.basePath) {
+        pathHistory = [widget.basePath];
+      } else {
+        // If the path is not already in history, add it.
+
+        if (pathHistory.isEmpty || pathHistory.last != path) {
+          // If this is a subdirectory of the base path, build proper history.
+
+          if (path.startsWith(widget.basePath)) {
+            pathHistory = [widget.basePath];
+            final relativePath = path.substring(widget.basePath.length);
+            if (relativePath.isNotEmpty && relativePath != '/') {
+              final segments =
+                  relativePath.split('/').where((s) => s.isNotEmpty);
+              var currentBuildPath = widget.basePath;
+              for (final segment in segments) {
+                currentBuildPath = '$currentBuildPath/$segment';
+                pathHistory.add(currentBuildPath);
+              }
+            }
+          } else {
+            // For paths outside base path, just add to history.
+
+            pathHistory.add(path);
+          }
+        }
+      }
       refreshFiles();
     });
+  }
+
+  /// Gets the effective friendly folder name based on the current path.
+  /// Uses SolidFileOperations for consistent title generation.
+
+  String _getEffectiveFriendlyFolderName() {
+    return SolidFileOperations.getFriendlyFolderName(
+        currentPath, widget.basePath);
   }
 
   @override
@@ -313,7 +352,7 @@ class SolidFileBrowserState extends State<SolidFileBrowser> {
                       isLoading: isLoading,
                       currentDirFileCount: currentDirFileCount,
                       currentDirDirectoryCount: currentDirDirectoryCount,
-                      friendlyFolderName: widget.friendlyFolderName,
+                      friendlyFolderName: _getEffectiveFriendlyFolderName(),
                       basePath: widget.basePath,
                     ),
 

--- a/lib/src/widgets/solid_file_browser.dart
+++ b/lib/src/widgets/solid_file_browser.dart
@@ -305,7 +305,9 @@ class SolidFileBrowserState extends State<SolidFileBrowser> {
 
   String _getEffectiveFriendlyFolderName() {
     return SolidFileOperations.getFriendlyFolderName(
-        currentPath, widget.basePath);
+        currentPath,
+        widget.basePath,
+    );
   }
 
   @override

--- a/lib/src/widgets/solid_file_operations.dart
+++ b/lib/src/widgets/solid_file_operations.dart
@@ -235,7 +235,7 @@ class SolidFileOperations {
   static String getFriendlyFolderName(String pathValue, String basePath) {
     final String root = basePath;
     if (pathValue.isEmpty || pathValue == root) {
-      return 'Home';
+      return 'Home Folder';
     }
 
     // Use path.basename to safely get the last component.


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Fixed the issue that the default FILES folder cannot be coordinated with te other tabs in the app.

- Link to associated issue: https://github.com/anusii/healthpod/pull/449#issuecomment-3272776261

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
- [x] Added 2 reviewers (or 1 for private repositories then they add another)

## Finalising

Once PR discussion is complete and 2 reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev
