### PR TITLE
Tony/448b migrate

### DIFF
--- a/lib/src/widgets/solid_file.dart
+++ b/lib/src/widgets/solid_file.dart
@@ -278,6 +278,19 @@ class _SolidFileState extends State<SolidFile> {
     _currentPath = widget.currentPath ?? widget.basePath;
   }
 
+  @override
+  void didUpdateWidget(covariant SolidFile oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final oldPath = oldWidget.currentPath ?? oldWidget.basePath;
+    final newPath = widget.currentPath ?? widget.basePath;
+
+    if (oldPath != newPath && newPath != _currentPath) {
+      setState(() {
+        _currentPath = newPath;
+      });
+    }
+  }
+
   /// Determines if we should use wide screen layout.
 
   bool _shouldUseWideScreen(BuildContext context) {

--- a/lib/src/widgets/solid_file_browser.dart
+++ b/lib/src/widgets/solid_file_browser.dart
@@ -298,6 +298,8 @@ class SolidFileBrowserState extends State<SolidFileBrowser> {
       }
       refreshFiles();
     });
+
+    widget.onDirectoryChanged.call(path);
   }
 
   /// Gets the effective friendly folder name based on the current path.

--- a/lib/src/widgets/solid_file_upload_config.dart
+++ b/lib/src/widgets/solid_file_upload_config.dart
@@ -118,7 +118,7 @@ class SolidFileUploadCallbacks {
   /// Creates a default instance with empty (no-op) callbacks for all
   /// operations. This allows all upload features to be enabled but with
   /// default behavior.
-  
+
   const SolidFileUploadCallbacks.defaults()
       : onUpload = _defaultCallback,
         onImportCsv = _defaultCallback,
@@ -131,7 +131,7 @@ class SolidFileUploadCallbacks {
 
   /// Creates a default instance with disabled callbacks (null values).
   /// This will make all upload features appear disabled/greyed out.
-  
+
   const SolidFileUploadCallbacks.disabled()
       : onUpload = null,
         onImportCsv = null,
@@ -143,7 +143,7 @@ class SolidFileUploadCallbacks {
         onConvertToJson = null;
 
   /// Default no-operation callback that does nothing when invoked.
-  
+
   static void _defaultCallback() {
     // Default implementation - no operation.
     // Users can override specific callbacks if needed.

--- a/lib/src/widgets/solid_file_upload_config.dart
+++ b/lib/src/widgets/solid_file_upload_config.dart
@@ -114,6 +114,40 @@ class SolidFileUploadCallbacks {
     this.onPreviewFile,
     this.onConvertToJson,
   });
+
+  /// Creates a default instance with empty (no-op) callbacks for all
+  /// operations. This allows all upload features to be enabled but with
+  /// default behavior.
+  
+  const SolidFileUploadCallbacks.defaults()
+      : onUpload = _defaultCallback,
+        onImportCsv = _defaultCallback,
+        onExportCsv = _defaultCallback,
+        onImportProfile = _defaultCallback,
+        onExportProfile = _defaultCallback,
+        onVisualiseJson = _defaultCallback,
+        onPreviewFile = _defaultCallback,
+        onConvertToJson = _defaultCallback;
+
+  /// Creates a default instance with disabled callbacks (null values).
+  /// This will make all upload features appear disabled/greyed out.
+  
+  const SolidFileUploadCallbacks.disabled()
+      : onUpload = null,
+        onImportCsv = null,
+        onExportCsv = null,
+        onImportProfile = null,
+        onExportProfile = null,
+        onVisualiseJson = null,
+        onPreviewFile = null,
+        onConvertToJson = null;
+
+  /// Default no-operation callback that does nothing when invoked.
+  
+  static void _defaultCallback() {
+    // Default implementation - no operation.
+    // Users can override specific callbacks if needed.
+  }
 }
 
 /// State information for the upload area.


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Fixed the issue in HealthPod that the button group beside the file browser cannot be synchronised with the changes of the current path.

- Link to associated issue: https://github.com/anusii/healthpod/issues/448

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
- [x] Added 2 reviewers (or 1 for private repositories then they add another)

## Finalising

Once PR discussion is complete and 2 reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev
