### PR TITLE
Drop SYSTEM MODE from THEME options

### DIFF
--- a/lib/src/widgets/solid_theme_models.dart
+++ b/lib/src/widgets/solid_theme_models.dart
@@ -126,9 +126,9 @@ class SolidThemeToggleConfig {
 ☀️ **Light Mode** (Current)
 
 Light Mode is best for viewing in light conditions. Tap here to switch to Dark
-Mode for low light conditions and then again for your System Mode.
+Mode for low light conditions.
 
-Cycle: ☀️ Light → 🌙 Dark → 🖥️ System
+Toggle: ☀️ Light ⇄ 🌙 Dark
 ''';
       case ThemeMode.dark:
         return '''
@@ -137,9 +137,9 @@ Cycle: ☀️ Light → 🌙 Dark → 🖥️ System
 🌙 **Dark Mode** (Current)
 
 Dark Mode is best for viewing in low light conditions. Tap here to switch to
-System Mode to follow your device settings and then again for Light Mode.
+Light Mode for bright viewing conditions.
 
-Cycle: ☀️ Light → 🌙 Dark → 🖥️ System
+Toggle: ☀️ Light ⇄ 🌙 Dark
 ''';
       case ThemeMode.system:
         return '''
@@ -147,10 +147,11 @@ Cycle: ☀️ Light → 🌙 Dark → 🖥️ System
 
 🖥️ **System Mode** (Current)
 
-System Mode follows your device settings. Tap here to switch to Light Mode and
-then again for Dark mode.
+System Mode follows your device settings. This is the initial mode. Tap here to
+switch to Light Mode, and afterwards toggle between Light and Dark modes.
 
-Cycle: ☀️ Light → 🌙 Dark → 🖥️ System
+First Switch: 🖥️ System → ☀️ Light
+Then Toggle: ☀️ Light ⇄ 🌙 Dark
 ''';
     }
   }
@@ -175,7 +176,7 @@ Cycle: ☀️ Light → 🌙 Dark → 🖥️ System
       case ThemeMode.light:
         return darkModeIcon ?? Icons.dark_mode;
       case ThemeMode.dark:
-        return systemModeIcon ?? Icons.computer;
+        return lightModeIcon ?? Icons.light_mode;
       case ThemeMode.system:
         return lightModeIcon ?? Icons.light_mode;
     }
@@ -208,10 +209,10 @@ Next: 🌙 **Dark Mode**
 
 🌙 **Dark Mode** (Current)
 
-Dark Mode is best for viewing in low light conditions. Tap here to switch to
-System Mode to follow your device settings.
+Dark Mode is best for viewing in low light conditions. Tap here to switch back
+to Light Mode for bright viewing conditions.
 
-Next: 🖥️ **System Mode**
+Next: ☀️ **Light Mode**
 ''';
       case ThemeMode.system:
         return '''
@@ -219,8 +220,8 @@ Next: 🖥️ **System Mode**
 
 🖥️ **System Mode** (Current)
 
-System Mode follows your device settings. Tap here to switch to Light Mode for
-bright viewing conditions.
+System Mode follows your device settings. This is the initial mode. Tap here to
+switch to Light Mode and begin toggling between Light and Dark modes.
 
 Next: ☀️ **Light Mode**
 ''';
@@ -234,7 +235,7 @@ Next: ☀️ **Light Mode**
       case ThemeMode.light:
         return 'Switch to Dark Mode 🌙';
       case ThemeMode.dark:
-        return 'Switch to System Mode 🖥️';
+        return 'Switch to Light Mode ☀️';
       case ThemeMode.system:
         return 'Switch to Light Mode ☀️';
     }

--- a/lib/src/widgets/solid_theme_notifier.dart
+++ b/lib/src/widgets/solid_theme_notifier.dart
@@ -130,7 +130,9 @@ class SolidThemeNotifier extends ChangeNotifier {
     await _saveThemeMode();
   }
 
-  /// Toggles between theme modes in the cycle: System → Light → Dark → System.
+  /// Toggles between theme modes.
+  /// On first toggle from System mode, switches to Light mode.
+  /// Afterwards, toggles only between Light and Dark modes.
 
   Future<void> toggleTheme() async {
     switch (_themeMode) {
@@ -141,7 +143,7 @@ class SolidThemeNotifier extends ChangeNotifier {
         await setThemeMode(ThemeMode.dark);
         break;
       case ThemeMode.dark:
-        await setThemeMode(ThemeMode.system);
+        await setThemeMode(ThemeMode.light);
         break;
     }
   }


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- The SYSTEM MODE is adjusted to be the default on application start up. From then on the button can only toggle between dark and light mode.

- Link to associated issue: #38

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [ ] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
- [x] Added 2 reviewers (or 1 for private repositories then they add another)

## Finalising

Once PR discussion is complete and 2 reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev
