### PR TITLE
Tony/158 navigate to subpage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ au](https://solidcommunity.au/docs/solidui)
 
 ## 0.1.0 First Release
 
++ Fixed page reload behaviour [0.0.20 20260108 tonypioneer]
 + Drop basePath: requirement from SolidFile() [0.0.20 20260107 tonypioneer]
 + Improve theme and appbar button preferences [0.0.19 20251219 tonypioneer]
 + Added version userTextStyle for accessibility [0.0.18 20251612 tonypioneer]

--- a/lib/src/widgets/solid_scaffold_controller.dart
+++ b/lib/src/widgets/solid_scaffold_controller.dart
@@ -54,17 +54,35 @@ import 'package:flutter/material.dart';
 
 class SolidScaffoldController extends ChangeNotifier {
   Widget? _currentSubpage;
+  int _navigationVersion = 0;
 
   /// Get the current subpage being displayed.
+  ///
+  /// The subpage is wrapped with a unique key to ensure it is rebuilt
+  /// each time [navigateToSubpage] is called, even for the same page type.
 
-  Widget? get currentSubpage => _currentSubpage;
+  Widget? get currentSubpage {
+    if (_currentSubpage == null) return null;
+
+    // Wrap with KeyedSubtree using the navigation version to force rebuild.
+
+    return KeyedSubtree(
+      key: ValueKey<int>(_navigationVersion),
+      child: _currentSubpage!,
+    );
+  }
 
   /// Navigate to a subpage.
   ///
   /// The subpage will be displayed using bodyOverride, taking precedence
   /// over menu-based navigation.
+  ///
+  /// Each call to this method will force a complete rebuild of the subpage,
+  /// even when navigating to the same page type. This ensures that the page
+  /// state is always refreshed.
 
   void navigateToSubpage(Widget subpage) {
+    _navigationVersion++;
     _currentSubpage = subpage;
     notifyListeners();
   }


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Fixed the issue that the navigateToSubpage() function cannot reload the same page.

## Associated Issue

- This PR relates to issue #158.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Call scaffoldController.navigateToSubpage(childPage) in NotePod to test.

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

- [ ] Screenshots included in linked issue #
- [x] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The update contains no confidential information
- [x] The update has no duplicated content
- [x] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [ ] Integration test `dart test` output or screenshot included in issue #
- [x] I tested the PR on these devices:
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
  - [ ] Web
- [x] I have identified reviewers
- [ ] The PR has been approved by reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [x] Merge dev into the this branch
- [x] Resolve any conflicts
- [x] Add a one line summary into the CHANGELOG.md
- [x] Push to the git repository and review
- [ ] Merge the PR into dev
