### PR TITLE
522_custom_folder_structure_at_initialisation_stage

### DIFF
--- a/example/lib/app.dart
+++ b/example/lib/app.dart
@@ -56,6 +56,11 @@ class App extends StatelessWidget {
       home: const SolidLogin(
         image: AssetImage('assets/images/app_image.jpg'),
         logo: AssetImage('assets/images/app_icon.jpg'),
+        customFolderPathList: [
+          'customDir1',
+          'customDir2',
+          'customDir2/customDir3',
+        ],
         child: appScaffold,
       ),
     );

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,7 +12,11 @@ dependencies:
     sdk: flutter
   markdown_tooltip: 0.0.10
   shared_preferences: ^2.5.4
-  solidpod: ^0.9.0
+  # solidpod: ^0.9.0
+  solidpod:
+    git:
+      url: https://github.com/anusii/solidui.git
+      ref: av/522_custom_folder_structure_at_initialisation_stage
   solidui:
     path: ..
   window_manager: ^0.5.1

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   # solidpod: ^0.9.0
   solidpod:
     git:
-      url: https://github.com/anusii/solidui.git
+      url: https://github.com/anusii/solidpod.git
       ref: av/522_custom_folder_structure_at_initialisation_stage
   solidui:
     path: ..

--- a/lib/src/widgets/solid_login.dart
+++ b/lib/src/widgets/solid_login.dart
@@ -38,6 +38,7 @@ import 'package:solidpod/solidpod.dart'
         getAppNameVersion,
         generateDefaultFolders,
         generateDefaultFiles,
+        generateCustomFolders,
         setAppDirName;
 import 'package:url_launcher/url_launcher.dart';
 
@@ -81,6 +82,7 @@ class SolidLogin extends StatefulWidget {
     this.changeKeyButtonStyle = const ChangeKeyButtonStyle(),
     this.themeConfig = const SolidLoginTheme(),
     this.snackbarConfig = const SnackbarConfig(),
+    this.customFolderPathList = const [],
     super.key,
   });
 
@@ -153,6 +155,17 @@ class SolidLogin extends StatefulWidget {
   /// Snackbar configuration for login notifications.
 
   final SnackbarConfig snackbarConfig;
+
+  /// Custom list of folders to be created inside the data folder.
+  /// Following are few examples.
+  ///   - Custom folder 'myDir1' will be created as '/data/myDir1'
+  ///   - Custom folder 'data' will be created as '/data/data'
+  /// If multi-level folder structure is needed you need to provide
+  /// upper level folders first in the list. For instance, to create
+  /// 'myDir1/myDir2/myDir3', add three values to the list as follows
+  /// in that order.
+  /// 'myDir1', 'myDir1/myDir2', 'myDir1/myDir2/myDir3'
+  final List customFolderPathList;
 
   @override
   State<SolidLogin> createState() => _SolidLoginState();
@@ -266,6 +279,8 @@ class _SolidLoginState extends State<SolidLogin> with WidgetsBindingObserver {
     final folders = await generateDefaultFolders();
     final files = await generateDefaultFiles();
 
+    final customFolders = generateCustomFolders(widget.customFolderPathList);
+
     // Check if widget is still mounted after async operations and before setState.
     // This prevents "setState() called after dispose()" errors that can occur
     // if the widget was disposed while async operations were running.
@@ -273,7 +288,7 @@ class _SolidLoginState extends State<SolidLogin> with WidgetsBindingObserver {
     if (!mounted) return;
 
     setState(() {
-      defaultFolders = folders;
+      defaultFolders = folders + customFolders;
       defaultFiles = files;
     });
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,11 @@ dependencies:
   path: ^1.9.1
   rdflib: ^0.2.12
   shared_preferences: ^2.5.4
-  solidpod: ^0.9.0
+  # solidpod: ^0.9.0
+  solidpod:
+    git:
+      url: https://github.com/anusii/solidui.git
+      ref: av/522_custom_folder_structure_at_initialisation_stage
   url_launcher: ^6.3.2
   version_widget: ^1.0.6
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   # solidpod: ^0.9.0
   solidpod:
     git:
-      url: https://github.com/anusii/solidui.git
+      url: https://github.com/anusii/solidpod.git
       ref: av/522_custom_folder_structure_at_initialisation_stage
   url_launcher: ^6.3.2
   version_widget: ^1.0.6


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Create custom folders inside the `data` folder at the initialisation stage

## Associated Issue

- This PR relates to issue https://github.com/anusii/solidpod/issues/522

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

- [ ] Screenshots included in linked issue #
- [x] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The update contains no confidential information
- [x] The update has no duplicated content
- [x] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [x] Integration test `dart test` output or screenshot included in issue #
- [x] I tested the PR on these devices:
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] MacOS
  - [x] Windows
  - [ ] Web
- [ ] I have identified reviewers
- [ ] The PR has been approved by reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the this branch
- [ ] Resolve any conflicts
- [ ] Add a one line summary into the CHANGELOG.md
- [ ] Push to the git repository and review
- [ ] Merge the PR into dev
