### PR TITLE
SOLIDUI: Customised Settings widget on AppBar (#27)

### DIFF
--- a/example/lib/app.dart
+++ b/example/lib/app.dart
@@ -44,14 +44,14 @@ class App extends StatelessWidget {
         ),
         useMaterial3: true,
       ),
-      home: const SolidLogin(
+      home: SolidLogin(
         title: 'SOLID POD DEMONSTRATOR',
         appDirectory: 'demopod',
-        image: AssetImage('assets/images/demopod_image.jpg'),
-        logo: AssetImage('assets/images/demopod_logo.png'),
+        image: const AssetImage('assets/images/demopod_image.jpg'),
+        logo: const AssetImage('assets/images/demopod_logo.png'),
         link: 'https://github.com/anusii/solidpod/blob/main/demopod/README.md',
         required: false,
-        infoButtonStyle: InfoButtonStyle(
+        infoButtonStyle: const InfoButtonStyle(
           tooltip: 'Visit the DemoPod documentation.',
         ),
         child: appScaffold,

--- a/example/lib/app_scaffold.dart
+++ b/example/lib/app_scaffold.dart
@@ -146,7 +146,7 @@ class _AppScaffoldState extends State<AppScaffold> {
         tooltip: 'Settings',
       ),
 
-      child: const Home(title: appTitle),
+      child: const Home(),
     );
   }
 }

--- a/example/lib/app_scaffold.dart
+++ b/example/lib/app_scaffold.dart
@@ -30,14 +30,28 @@ import 'package:solidui/solidui.dart';
 import 'package:demopod/constants/app.dart';
 import 'package:demopod/home.dart';
 
-const appScaffold = AppScaffold();
+final appScaffold = AppScaffold();
 
-class AppScaffold extends StatelessWidget {
+class AppScaffold extends StatefulWidget {
   const AppScaffold({super.key});
+
+  @override
+  State<AppScaffold> createState() => _AppScaffoldState();
+}
+
+class _AppScaffoldState extends State<AppScaffold> {
+  final _scaffoldController = SolidScaffoldController();
+
+  @override
+  void dispose() {
+    _scaffoldController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return SolidScaffold(
+      controller: _scaffoldController,
       menu: const [
         SolidMenuItem(
           icon: Icons.home,
@@ -121,7 +135,30 @@ class AppScaffold extends StatelessWidget {
       ),
       enableProfile: true,
       onLogout: (context) => SolidAuthHandler.instance.handleLogout(context),
-      child: const Home(),
+
+      // SETTINGS.
+
+      settingsWidget: IconButton(
+        icon: const Icon(Icons.settings),
+        onPressed: () => _scaffoldController.navigateToSubpage(
+          const _MySettings(),
+        ),
+        tooltip: 'Settings',
+      ),
+
+      child: const Home(title: appTitle),
+    );
+  }
+}
+
+class _MySettings extends StatelessWidget {
+  const _MySettings();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Custom Settings')),
+      body: const Center(child: Text('This is a custom settings page.')),
     );
   }
 }

--- a/example/lib/app_scaffold.dart
+++ b/example/lib/app_scaffold.dart
@@ -181,7 +181,29 @@ class AppScaffold extends StatelessWidget {
 
       onLogout: (context) => SolidAuthHandler.instance.handleLogout(context),
 
+      // SETTINGS.
+
+      settingsWidget: IconButton(
+        icon: const Icon(Icons.settings),
+        onPressed: () => _scaffoldController.navigateToSubpage(
+          const _MySettings(),
+        ),
+        tooltip: 'Settings',
+      ),
+
       child: const Home(title: appTitle),
+    );
+  }
+}
+
+class _MySettings extends StatelessWidget {
+  const _MySettings();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Custom Settings')),
+      body: const Center(child: Text('This is a custom settings page.')),
     );
   }
 }

--- a/lib/solidui.dart
+++ b/lib/solidui.dart
@@ -111,6 +111,7 @@ export 'src/utils/solid_file_operations_print.dart';
 export 'src/utils/is_phone.dart';
 export 'src/utils/solid_alert.dart';
 export 'src/utils/solid_notifications.dart';
+export 'src/utils/path_utils.dart';
 export 'src/utils/solid_pod_helpers.dart'
     show loginIfRequired, getKeyFromUserIfRequired;
 export 'src/utils/web_id_parser.dart';

--- a/lib/solidui.dart
+++ b/lib/solidui.dart
@@ -102,6 +102,7 @@ export 'src/utils/solid_file_operations.dart';
 export 'src/utils/is_phone.dart';
 export 'src/utils/solid_alert.dart';
 export 'src/utils/solid_notifications.dart';
+export 'src/utils/path_utils.dart';
 export 'src/utils/solid_pod_helpers.dart'
     show loginIfRequired, getKeyFromUserIfRequired;
 

--- a/lib/src/widgets/solid_nav_bar.dart
+++ b/lib/src/widgets/solid_nav_bar.dart
@@ -75,6 +75,10 @@ class SolidNavBar extends StatelessWidget {
 
   final double? labelFontSize;
 
+  /// Optional custom Settings widget.
+
+  final Widget? settingsWidget;
+
   /// Creates a [SolidNavBar] with the specified configuration.
 
   const SolidNavBar({
@@ -87,6 +91,7 @@ class SolidNavBar extends StatelessWidget {
     this.groupAlignment,
     this.iconSize,
     this.labelFontSize,
+    this.settingsWidget,
   });
 
   @override
@@ -165,6 +170,12 @@ class SolidNavBar extends StatelessWidget {
                   letterSpacing: NavigationConstants.navLabelLetterSpacing,
                   color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
                 ),
+                trailing: settingsWidget != null
+                    ? Padding(
+                        padding: const EdgeInsets.only(bottom: 20),
+                        child: settingsWidget,
+                      )
+                    : null,
               ),
             ),
           ),

--- a/lib/src/widgets/solid_nav_bar.dart
+++ b/lib/src/widgets/solid_nav_bar.dart
@@ -75,6 +75,10 @@ class SolidNavBar extends StatelessWidget {
 
   final double? labelFontSize;
 
+  /// Optional custom Settings widget.
+
+  final Widget? settingsWidget;
+
   /// Creates a [SolidNavBar] with the specified configuration.
 
   const SolidNavBar({
@@ -87,6 +91,7 @@ class SolidNavBar extends StatelessWidget {
     this.groupAlignment,
     this.iconSize,
     this.labelFontSize,
+    this.settingsWidget,
   });
 
   @override
@@ -191,6 +196,12 @@ class SolidNavBar extends StatelessWidget {
                   letterSpacing: NavigationConstants.navLabelLetterSpacing,
                   color: cs.onSurfaceVariant.withValues(alpha: 0.6),
                 ),
+                trailing: settingsWidget != null
+                    ? Padding(
+                        padding: const EdgeInsets.only(bottom: 20),
+                        child: settingsWidget,
+                      )
+                    : null,
               ),
             ),
           ),

--- a/lib/src/widgets/solid_nav_drawer.dart
+++ b/lib/src/widgets/solid_nav_drawer.dart
@@ -99,6 +99,10 @@ class SolidNavDrawer extends StatefulWidget {
 
   final ShapeBorder? drawerShape;
 
+  /// Optional custom Settings widget.
+
+  final Widget? settingsWidget;
+
   const SolidNavDrawer({
     super.key,
     this.userInfo,
@@ -114,6 +118,7 @@ class SolidNavDrawer extends StatefulWidget {
     this.securityKeyStatus,
     this.additionalMenuItems,
     this.drawerShape,
+    this.settingsWidget,
   });
 
   @override
@@ -201,6 +206,11 @@ class _SolidNavDrawerState extends State<SolidNavDrawer> {
                 }),
                 if (widget.additionalMenuItems != null)
                   ...widget.additionalMenuItems!,
+                if (widget.settingsWidget != null)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 8.0),
+                    child: widget.settingsWidget,
+                  ),
                 if (widget.securityKeyStatus != null ||
                     widget.onUserNameTap != null)
                   ..._buildBottomSection(context, theme),

--- a/lib/src/widgets/solid_nav_drawer.dart
+++ b/lib/src/widgets/solid_nav_drawer.dart
@@ -81,6 +81,10 @@ class SolidNavDrawer extends StatefulWidget {
 
   final ShapeBorder? drawerShape;
 
+  /// Optional custom Settings widget.
+
+  final Widget? settingsWidget;
+
   const SolidNavDrawer({
     super.key,
     this.userInfo,
@@ -93,6 +97,7 @@ class SolidNavDrawer extends StatefulWidget {
     this.showLogout = true,
     this.additionalMenuItems,
     this.drawerShape,
+    this.settingsWidget,
   });
 
   @override
@@ -175,6 +180,11 @@ class _SolidNavDrawerState extends State<SolidNavDrawer> {
                 }),
                 if (widget.additionalMenuItems != null)
                   ...widget.additionalMenuItems!,
+                if (widget.settingsWidget != null)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 8.0),
+                    child: widget.settingsWidget,
+                  ),
                 if (widget.showLogout && widget.onLogout != null)
                   ..._buildLogoutSection(context, theme),
               ],

--- a/lib/src/widgets/solid_scaffold.dart
+++ b/lib/src/widgets/solid_scaffold.dart
@@ -238,6 +238,10 @@ class SolidScaffold extends StatefulWidget {
 
   final SolidAboutConfig? aboutConfig;
 
+  /// Optional custom Settings widget.
+
+  final Widget? settingsWidget;
+
   /// Option to force the navigation rail to be hidden.
 
   final bool hideNavRail;
@@ -293,6 +297,7 @@ class SolidScaffold extends StatefulWidget {
     this.selectedIndex,
     this.themeToggle,
     this.aboutConfig,
+    this.settingsWidget,
     this.hideNavRail = false,
     this.enableProfile = false,
   });

--- a/lib/src/widgets/solid_scaffold.dart
+++ b/lib/src/widgets/solid_scaffold.dart
@@ -231,6 +231,10 @@ class SolidScaffold extends StatefulWidget {
 
   final SolidAboutConfig? aboutConfig;
 
+  /// Optional custom Settings widget.
+
+  final Widget? settingsWidget;
+
   /// Option to force the navigation rail to be hidden.
 
   final bool hideNavRail;
@@ -278,6 +282,7 @@ class SolidScaffold extends StatefulWidget {
     this.selectedIndex,
     this.themeToggle,
     this.aboutConfig,
+    this.settingsWidget,
     this.hideNavRail = false,
   });
 

--- a/lib/src/widgets/solid_scaffold_appbar_actions.dart
+++ b/lib/src/widgets/solid_scaffold_appbar_actions.dart
@@ -51,13 +51,20 @@ class SolidAppBarActionsManager {
     SolidThemeToggleConfig? themeToggle, {
     bool hasLogout = false,
     bool hasLogin = true,
+    bool hasSettings = false,
   }) {
     // Check if we need to add missing buttons (standard or custom).
 
     final existingActions = solidPreferencesNotifier.appBarActions;
     final needsInit = existingActions.isEmpty;
     final needsMerge = !needsInit &&
-        _hasMissingButtons(existingActions, config, themeToggle, hasLogout);
+        _hasMissingButtons(
+          existingActions,
+          config,
+          themeToggle,
+          hasLogout,
+          hasSettings,
+        );
 
     if (!needsInit && !needsMerge) return;
 
@@ -142,6 +149,22 @@ class SolidAppBarActionsManager {
       );
     }
 
+    // Add Settings button if provided.
+
+    if (hasSettings) {
+      actionEntries.add(
+        _ActionEntry(
+          item: const SolidAppBarActionItem(
+            id: SolidAppBarActionIds.preferences,
+            label: 'Settings',
+            icon: Icons.settings,
+            showInOverflow: false, // Show in AppBar by default.
+          ),
+          initialIndex: 850, // Settings button just before About.
+        ),
+      );
+    }
+
     // Add About button.
     // Default: show in AppBar, rightmost position.
 
@@ -188,6 +211,7 @@ class SolidAppBarActionsManager {
     SolidAppBarConfig config,
     SolidThemeToggleConfig? themeToggle,
     bool hasLogout,
+    bool hasSettings,
   ) {
     final existingIds = actions.map((a) => a.id).toSet();
 
@@ -218,6 +242,12 @@ class SolidAppBarActionsManager {
 
     if (hasLogout) {
       expectedIds.add(SolidAppBarActionIds.logout);
+    }
+
+    // Settings button (if provided).
+
+    if (hasSettings) {
+      expectedIds.add(SolidAppBarActionIds.preferences);
     }
 
     // About button should always exist.

--- a/lib/src/widgets/solid_scaffold_appbar_actions.dart
+++ b/lib/src/widgets/solid_scaffold_appbar_actions.dart
@@ -50,13 +50,20 @@ class SolidAppBarActionsManager {
     SolidAppBarConfig config,
     SolidThemeToggleConfig? themeToggle, {
     bool hasLogout = false,
+    bool hasSettings = false,
   }) {
     // Check if we need to add missing buttons (standard or custom).
 
     final existingActions = solidPreferencesNotifier.appBarActions;
     final needsInit = existingActions.isEmpty;
     final needsMerge = !needsInit &&
-        _hasMissingButtons(existingActions, config, themeToggle, hasLogout);
+        _hasMissingButtons(
+          existingActions,
+          config,
+          themeToggle,
+          hasLogout,
+          hasSettings,
+        );
 
     if (!needsInit && !needsMerge) return;
 
@@ -141,6 +148,22 @@ class SolidAppBarActionsManager {
       );
     }
 
+    // Add Settings button if provided.
+
+    if (hasSettings) {
+      actionEntries.add(
+        _ActionEntry(
+          item: const SolidAppBarActionItem(
+            id: SolidAppBarActionIds.preferences,
+            label: 'Settings',
+            icon: Icons.settings,
+            showInOverflow: false, // Show in AppBar by default.
+          ),
+          initialIndex: 850, // Settings button just before About.
+        ),
+      );
+    }
+
     // Add About button.
     // Default: show in AppBar, rightmost position.
 
@@ -182,6 +205,7 @@ class SolidAppBarActionsManager {
     SolidAppBarConfig config,
     SolidThemeToggleConfig? themeToggle,
     bool hasLogout,
+    bool hasSettings,
   ) {
     final existingIds = actions.map((a) => a.id).toSet();
 
@@ -212,6 +236,12 @@ class SolidAppBarActionsManager {
 
     if (hasLogout) {
       expectedIds.add(SolidAppBarActionIds.logout);
+    }
+
+    // Settings button (if provided).
+
+    if (hasSettings) {
+      expectedIds.add(SolidAppBarActionIds.preferences);
     }
 
     // About button should always exist.

--- a/lib/src/widgets/solid_scaffold_appbar_builder.dart
+++ b/lib/src/widgets/solid_scaffold_appbar_builder.dart
@@ -59,6 +59,7 @@ class SolidScaffoldAppBarBuilder {
     VoidCallback? themeToggleCallback,
     SolidAboutConfig aboutConfig,
     double narrowScreenThreshold, {
+    Widget? settingsWidget,
     bool hideNavRail = false,
     bool showLogout = true,
     bool showLogin = true,
@@ -72,6 +73,7 @@ class SolidScaffoldAppBarBuilder {
       themeToggle,
       hasLogout: showLogout,
       hasLogin: showLogin,
+      hasSettings: settingsWidget != null,
     );
 
     final layoutWidth = constraints.maxWidth;
@@ -105,6 +107,7 @@ class SolidScaffoldAppBarBuilder {
       currentThemeMode: currentThemeMode,
       themeToggleCallback: themeToggleCallback,
       aboutConfig: aboutConfig,
+      settingsWidget: settingsWidget,
       context: context,
       showLogout: showLogout,
       showLogin: showLogin,

--- a/lib/src/widgets/solid_scaffold_appbar_builder.dart
+++ b/lib/src/widgets/solid_scaffold_appbar_builder.dart
@@ -55,6 +55,7 @@ class SolidScaffoldAppBarBuilder {
     VoidCallback? themeToggleCallback,
     SolidAboutConfig aboutConfig,
     double narrowScreenThreshold, {
+    Widget? settingsWidget,
     bool hideNavRail = false,
     void Function(BuildContext)? onLogout,
     void Function(BuildContext)? onLogin,
@@ -65,6 +66,7 @@ class SolidScaffoldAppBarBuilder {
       config,
       themeToggle,
       hasLogout: true,
+      hasSettings: settingsWidget != null,
     );
 
     final isWideScreen = !hideNavRail &&
@@ -100,6 +102,7 @@ class SolidScaffoldAppBarBuilder {
       currentThemeMode: currentThemeMode,
       themeToggleCallback: themeToggleCallback,
       aboutConfig: aboutConfig,
+      settingsWidget: settingsWidget,
       context: context,
       onLogout: onLogout,
       onLogin: onLogin,

--- a/lib/src/widgets/solid_scaffold_appbar_ordered_actions.dart
+++ b/lib/src/widgets/solid_scaffold_appbar_ordered_actions.dart
@@ -58,6 +58,7 @@ class SolidAppBarOrderedActionsBuilder {
     required VoidCallback? themeToggleCallback,
     required SolidAboutConfig aboutConfig,
     required BuildContext context,
+    Widget? settingsWidget,
     void Function(BuildContext)? onLogout,
     void Function(BuildContext)? onLogin,
   }) {
@@ -76,6 +77,7 @@ class SolidAppBarOrderedActionsBuilder {
     _addCustomActions(orderedActions, config, screenWidth, isNarrowScreen);
     _addOverflowItems(orderedActions, config, isNarrowScreen);
     _addAuthButton(orderedActions, onLogout, onLogin, isNarrowScreen, context);
+    _addSettingsButton(orderedActions, settingsWidget, isNarrowScreen);
     _addAboutButton(
       orderedActions,
       aboutConfig,
@@ -216,6 +218,27 @@ class SolidAppBarOrderedActionsBuilder {
           order: order,
           widget: SolidDynamicAuthButton(onLogout: onLogout, onLogin: onLogin),
         ),
+      );
+    }
+  }
+
+  static void _addSettingsButton(
+    List<_OrderedAction> orderedActions,
+    Widget? settingsWidget,
+    bool isNarrowScreen,
+  ) {
+    if (settingsWidget == null) return;
+
+    final actionConfig = SolidAppBarActionsManager.getActionConfig(
+      SolidAppBarActionIds.preferences,
+    );
+    final isVisible = actionConfig?.isVisible ?? true;
+    final isInOverflow = actionConfig?.showInOverflow ?? false;
+    final order = actionConfig?.order ?? 850;
+
+    if (isVisible && (!isNarrowScreen || !isInOverflow)) {
+      orderedActions.add(
+        _OrderedAction(order: order, widget: settingsWidget),
       );
     }
   }

--- a/lib/src/widgets/solid_scaffold_appbar_ordered_actions.dart
+++ b/lib/src/widgets/solid_scaffold_appbar_ordered_actions.dart
@@ -60,6 +60,7 @@ class SolidAppBarOrderedActionsBuilder {
     required BuildContext context,
     bool showLogout = true,
     bool showLogin = true,
+    Widget? settingsWidget,
     void Function(BuildContext)? onLogout,
     void Function(BuildContext)? onLogin,
   }) {
@@ -86,6 +87,7 @@ class SolidAppBarOrderedActionsBuilder {
       isVeryNarrowScreen,
       context,
     );
+    _addSettingsButton(orderedActions, settingsWidget, isVeryNarrowScreen);
     _addAboutButton(
       orderedActions,
       aboutConfig,
@@ -240,6 +242,27 @@ class SolidAppBarOrderedActionsBuilder {
             onLogin: onLogin,
           ),
         ),
+      );
+    }
+  }
+
+  static void _addSettingsButton(
+    List<_OrderedAction> orderedActions,
+    Widget? settingsWidget,
+    bool isNarrowScreen,
+  ) {
+    if (settingsWidget == null) return;
+
+    final actionConfig = SolidAppBarActionsManager.getActionConfig(
+      SolidAppBarActionIds.preferences,
+    );
+    final isVisible = actionConfig?.isVisible ?? true;
+    final isInOverflow = actionConfig?.showInOverflow ?? false;
+    final order = actionConfig?.order ?? 850;
+
+    if (isVisible && (!isNarrowScreen || !isInOverflow)) {
+      orderedActions.add(
+        _OrderedAction(order: order, widget: settingsWidget),
       );
     }
   }

--- a/lib/src/widgets/solid_scaffold_helpers.dart
+++ b/lib/src/widgets/solid_scaffold_helpers.dart
@@ -303,6 +303,7 @@ class SolidScaffoldHelpers {
     double narrowScreenThreshold,
     bool Function() shouldShowVersion,
     String Function() getVersionToDisplay, {
+    Widget? settingsWidget,
     bool hideNavRail = false,
     bool showLogout = true,
     bool showLogin = true,
@@ -323,6 +324,7 @@ class SolidScaffoldHelpers {
       themeToggleCallback,
       aboutConfig,
       narrowScreenThreshold,
+      settingsWidget: settingsWidget,
       hideNavRail: hideNavRail,
       showLogout: showLogout,
       showLogin: showLogin,

--- a/lib/src/widgets/solid_scaffold_helpers.dart
+++ b/lib/src/widgets/solid_scaffold_helpers.dart
@@ -253,6 +253,7 @@ class SolidScaffoldHelpers {
     double narrowScreenThreshold,
     bool Function() shouldShowVersion,
     String Function() getVersionToDisplay, {
+    Widget? settingsWidget,
     bool hideNavRail = false,
     void Function(BuildContext)? onLogout,
     void Function(BuildContext)? onLogin,
@@ -269,6 +270,7 @@ class SolidScaffoldHelpers {
       themeToggleCallback,
       aboutConfig,
       narrowScreenThreshold,
+      settingsWidget: settingsWidget,
       hideNavRail: hideNavRail,
       onLogout: onLogout,
       onLogin: onLogin,

--- a/lib/src/widgets/solid_scaffold_layout_builder.dart
+++ b/lib/src/widgets/solid_scaffold_layout_builder.dart
@@ -51,8 +51,9 @@ class SolidScaffoldLayoutBuilder {
     int? selectedIndex,
     Widget? effectiveChild,
     Function(int) onTabSelected,
-    Function(BuildContext, String, String?)? onShowAlert,
-  ) {
+    Function(BuildContext, String, String?)? onShowAlert, {
+    Widget? settingsWidget,
+  }) {
     final theme = Theme.of(context);
 
     if (effectiveChild == null) {
@@ -73,6 +74,7 @@ class SolidScaffoldLayoutBuilder {
                   selectedIndex: selectedIndex,
                   onTabSelected: onTabSelected,
                   onShowAlert: onShowAlert,
+                  settingsWidget: settingsWidget,
                 ),
                 Expanded(child: effectiveChild),
               ],

--- a/lib/src/widgets/solid_scaffold_layout_builder.dart
+++ b/lib/src/widgets/solid_scaffold_layout_builder.dart
@@ -51,8 +51,9 @@ class SolidScaffoldLayoutBuilder {
     int? selectedIndex,
     Widget? effectiveChild,
     Function(int) onTabSelected,
-    Function(BuildContext, String, String?)? onShowAlert,
-  ) {
+    Function(BuildContext, String, String?)? onShowAlert, {
+    Widget? settingsWidget,
+  }) {
     final theme = Theme.of(context);
 
     if (effectiveChild == null) {
@@ -73,6 +74,7 @@ class SolidScaffoldLayoutBuilder {
                   selectedIndex: selectedIndex,
                   onTabSelected: onTabSelected,
                   onShowAlert: onShowAlert,
+                  settingsWidget: settingsWidget,
                 ),
                 VerticalDivider(width: 1, color: theme.dividerColor),
                 Expanded(child: effectiveChild),

--- a/lib/src/widgets/solid_scaffold_state.dart
+++ b/lib/src/widgets/solid_scaffold_state.dart
@@ -206,6 +206,7 @@ class SolidScaffoldState extends State<SolidScaffold> {
             ),
             _onMenuSelected,
             widget.onShowAlert,
+            settingsWidget: widget.settingsWidget,
           );
 
     return NotificationListener<SecurityKeyStatusChangedNotification>(

--- a/lib/src/widgets/solid_scaffold_state.dart
+++ b/lib/src/widgets/solid_scaffold_state.dart
@@ -225,6 +225,7 @@ class SolidScaffoldState extends State<SolidScaffold> {
                 ),
                 _onMenuSelected,
                 widget.onShowAlert,
+                settingsWidget: widget.settingsWidget,
               );
 
         return NotificationListener<SecurityKeyStatusChangedNotification>(

--- a/lib/src/widgets/solid_scaffold_widget_builder.dart
+++ b/lib/src/widgets/solid_scaffold_widget_builder.dart
@@ -140,6 +140,7 @@ class SolidScaffoldWidgetBuilder {
           widget.narrowScreenThreshold,
           shouldShowVersion,
           getVersionToDisplay,
+          settingsWidget: widget.settingsWidget,
           hideNavRail: widget.hideNavRail,
           onLogout: effectiveLogout,
           onLogin: effectiveLogin,
@@ -158,6 +159,7 @@ class SolidScaffoldWidgetBuilder {
           onTabSelected: onMenuSelected,
           onLogout: effectiveLogout,
           showLogout: effectiveLogout != null,
+          settingsWidget: widget.settingsWidget,
         );
       },
       endDrawer: widget.endDrawer,

--- a/lib/src/widgets/solid_scaffold_widget_builder.dart
+++ b/lib/src/widgets/solid_scaffold_widget_builder.dart
@@ -165,6 +165,7 @@ class SolidScaffoldWidgetBuilder {
           widget.narrowScreenThreshold,
           shouldShowVersion,
           getVersionToDisplay,
+          settingsWidget: widget.settingsWidget,
           hideNavRail: widget.hideNavRail,
           showLogout: widget.showLogout,
           showLogin: widget.showLogin,
@@ -191,6 +192,7 @@ class SolidScaffoldWidgetBuilder {
           onUserNameTap: (drawerContext) =>
               SolidAuthHandler.instance.handleAuthAction(drawerContext),
           securityKeyStatus: _buildDrawerSecurityKeyStatus(widget, isKeySaved),
+          settingsWidget: widget.settingsWidget,
         );
       },
       endDrawer: widget.endDrawer,


### PR DESCRIPTION
This change adds a settingsWidget parameter to SolidScaffold, allowing developers to define their own settings widget (e.g., an IconButton) which is then displayed in the AppBar next to the About button. It also integrates this widget into the Navigation Rail (trailing) and the Navigation Drawer.

## Associated Issue

- This PR relates to issue #27

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Verified using the example application by adding a custom IconButton to the settingsWidget parameter.
- Confirmed the widget appears in the AppBar, Navigation Rail (trailing), and Navigation Drawer.
- Verified that the widget correctly navigates to a custom subpage.
- Ran 'flutter analyze' and confirmed no lint issues were introduced.

## Checklist

- [x] Screenshots included in linked issue #27
- [x] Changes adhere to the style and coding guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The update contains no confidential information
- [x] The update has no duplicated content
- [x] No lint check errors are related to these changes
- [ ] Integration test output or screenshot included in issue #27
- [x] I tested the PR on these devices:
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] MacOS
  - [x] Windows
  - [ ] Web
- [ ] I have identified reviewers
- [ ] The PR has been approved by reviewers