### PR TITLE
enable status bar to update immidiately

### DIFF
--- a/lib/src/utils/solid_pod_helpers.dart
+++ b/lib/src/utils/solid_pod_helpers.dart
@@ -35,6 +35,8 @@ import 'package:solidpod/solidpod.dart'
     show isUserLoggedIn, getWebId, KeyManager, verifySecurityKey;
 
 import 'package:solidui/src/constants/ui.dart' show SecurityStrings;
+import 'package:solidui/src/services/solid_security_key_notifier.dart'
+    show securityKeyNotifier;
 import 'package:solidui/src/widgets/security_key_ui.dart' show SecurityKeyUI;
 import 'package:solidui/src/widgets/solid_login_webid_input_dialog.dart';
 
@@ -101,6 +103,9 @@ Future<void> getKeyFromUserIfRequired(
         context,
         MaterialPageRoute(builder: (context) => securityKeyInput),
       );
+      // Notify the global status bar notifier that the key status may have
+      // changed after the user submitted (or dismissed) the key prompt.
+      await securityKeyNotifier.refreshStatus();
     }
   }
 }


### PR DESCRIPTION
# Pull Request Details

This PR enable status bar to update immidiately after entering a correct security key.

## Associated Issue

- This PR relates to [issue #](https://github.com/anusii/notepod/issues/346)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Complete the check-list below to ensure your branch is ready for PR.

- [ ] Screenshots included in linked issue #
- [ ] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] The update contains no confidential information
- [ ] The update has no duplicated content
- [ ] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [ ] Integration test `dart test` output or screenshot included in issue #
- [ ] I tested the PR on these devices:
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] MacOS
  - [ ] Windows
  - [x] Web
- [ ] I have identified reviewers
- [ ] The PR has been approved by reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the this branch
- [ ] Resolve any conflicts
- [ ] Add a one line summary into the CHANGELOG.md
- [ ] Push to the git repository and review
- [x] Merge the PR into dev
