### PR TITLE
List number of items rather than number of files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 # Generic Makefile
 #
-# Time-stamp: <Saturday 2026-01-03 16:58:59 +1100 Graham Williams>
+# Time-stamp: <Wednesday 2026-03-18 12:22:03 +1100 Graham Williams>
 #
 # Copyright (c) Graham.Williams@togaware.com
 #
@@ -188,3 +188,12 @@ ginfo:
 	else \
 		echo "No bump ID found."; \
 	fi
+
+.PHONY: zip
+zip:
+	rm -f ignore/my_lib.zip
+	zip -r ignore/my_lib.zip lib
+
+.PHONY: claude
+claude:
+	bash support/meld_zip_from_claude.sh

--- a/lib/src/utils/file_operations.dart
+++ b/lib/src/utils/file_operations.dart
@@ -168,7 +168,7 @@ class FileOperations {
     String currentPath,
     List<String> directories,
   ) async {
-    // Count files in each subdirectory.
+    // Count items (files + folders) in each subdirectory.
 
     final counts = <String, int>{};
     for (var dir in directories) {
@@ -179,24 +179,26 @@ class FileOperations {
     return counts;
   }
 
-  /// Counts the number of files in a directory.
+  /// Counts the total number of items (files and folders) in a directory.
   ///
   /// Parameters:
-  /// - [dirPath]: The directory path to count files in.
+  /// - [dirPath]: The directory path to count items in.
   ///
-  /// Returns the number of files in the directory, or 0 if an error occurs.
+  /// Returns the number of files and subdirectories, or 0 if an error occurs.
 
   static Future<int> getDirectoryFileCount(String dirPath) async {
     try {
-      // Get directory contents and count files.
+      // Get directory contents and count both files and subdirectories.
 
       final dirUrl = await getDirUrl(dirPath);
       final resources = await getResourcesInContainer(dirUrl);
-      return resources.files
+      final fileCount = resources.files
           .where((f) => f.endsWith('.enc.ttl') || f.endsWith('.ttl'))
           .length;
+
+      return fileCount + resources.subDirs.length;
     } catch (e) {
-      debugPrint('Error counting files in directory: $e');
+      debugPrint('Error counting items in directory: $e');
       return 0;
     }
   }

--- a/lib/src/widgets/solid_file_directory_list.dart
+++ b/lib/src/widgets/solid_file_directory_list.dart
@@ -30,14 +30,14 @@ library;
 
 import 'package:flutter/material.dart';
 
-/// A widget that displays a list of directories with their file counts.
+/// A widget that displays a list of directories with their item counts.
 
 class DirectoryList extends StatelessWidget {
   /// List of directory names to display.
 
   final List<String> directories;
 
-  /// Map of directory names to their file counts.
+  /// Map of directory names to their item counts (files + folders).
 
   final Map<String, int> directoryCounts;
 
@@ -172,7 +172,7 @@ class DirectoryList extends StatelessWidget {
                   ),
                 ),
 
-                // File count badge. Shows a compact loading indicator while
+                // Item count badge. Shows a compact loading indicator while
                 // counts are being fetched in the background.
 
                 if (directoryCounts.containsKey(dir))
@@ -188,7 +188,8 @@ class DirectoryList extends StatelessWidget {
                       borderRadius: BorderRadius.circular(12),
                     ),
                     child: Text(
-                      '${directoryCounts[dir]} files',
+                      '${directoryCounts[dir]}'
+                      ' item${directoryCounts[dir] == 1 ? '' : 's'}',
                       style: TextStyle(
                         fontSize: 12,
                         color: Theme.of(context).textTheme.bodySmall?.color,

--- a/lib/src/widgets/solid_file_path_bar.dart
+++ b/lib/src/widgets/solid_file_path_bar.dart
@@ -330,10 +330,14 @@ class PathBar extends StatelessWidget {
                 else
                   Builder(
                     builder: (context) {
-                      final totalItems =
+                      final total =
                           currentDirDirectoryCount + currentDirFileCount;
+                      final dirs = currentDirDirectoryCount;
+                      final files = currentDirFileCount;
                       return Text(
-                        '$totalItems item${totalItems == 1 ? '' : 's'}',
+                        '$total item${total == 1 ? '' : 's'}'
+                        ' ($dirs director${dirs == 1 ? 'y' : 'ies'}'
+                        ' and $files file${files == 1 ? '' : 's'})',
                         style: TextStyle(
                           color: Theme.of(context).textTheme.bodySmall?.color,
                           fontSize: 12,

--- a/lib/src/widgets/solid_file_path_bar.dart
+++ b/lib/src/widgets/solid_file_path_bar.dart
@@ -328,24 +328,18 @@ class PathBar extends StatelessWidget {
                     ),
                   )
                 else
-                  Row(
-                    children: [
-                      Text(
-                        'Directories: $currentDirDirectoryCount',
+                  Builder(
+                    builder: (context) {
+                      final totalItems =
+                          currentDirDirectoryCount + currentDirFileCount;
+                      return Text(
+                        '$totalItems item${totalItems == 1 ? '' : 's'}',
                         style: TextStyle(
                           color: Theme.of(context).textTheme.bodySmall?.color,
                           fontSize: 12,
                         ),
-                      ),
-                      const SizedBox(width: 8),
-                      Text(
-                        'Files: $currentDirFileCount',
-                        style: TextStyle(
-                          color: Theme.of(context).textTheme.bodySmall?.color,
-                          fontSize: 12,
-                        ),
-                      ),
-                    ],
+                      );
+                    },
                   ),
 
                 const SizedBox(width: 12),

--- a/support/meld_zip_from_claude.sh
+++ b/support/meld_zip_from_claude.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Check if a filename was provided
+
+if [ $# -ne 0 ]; then
+    echo "Usage: $0"
+    exit 1
+fi
+
+appname=$(basename $PWD)
+
+# Find the latest zip file to run meld across.
+
+FIND_CLAUDE=$(find ~/Downloads -name "${appname}_lib*.zip" 2>/dev/null | head -1)
+echo "Found ${FIND_CLAUDE}"
+
+if [ -z "$FIND_CLAUDE" ]; then
+    echo "Error: can not find the Claude zip file in Downloads ${appname}_lib.zip"
+    exit 1
+fi
+
+# Create a temporary folder to work in
+
+mkdir tmp
+
+# Extract the zip file.
+
+(cd tmp; unzip "${FIND_CLAUDE}")
+
+# Run meld with the file and find result
+
+meld tmp/lib lib
+
+# Remove the file after meld closes
+
+rm -rf tmp
+rm -i "${FIND_CLAUDE}"


### PR DESCRIPTION
Currently the listing in FileBrowser() shows only the number of files in a folder. It does not count the number of folders as well. Instead list the total number of files/folders in a folder. This way I won't think the folder is empty if it just contains folders