### PR TITLE
Suppress character preview on Apple

### DIFF
--- a/lib/src/screens/initial_setup_widgets/enc_key_input_form.dart
+++ b/lib/src/screens/initial_setup_widgets/enc_key_input_form.dart
@@ -98,6 +98,8 @@ class _EncKeyInputFormState extends State<EncKeyInputForm> {
               child: FormBuilderTextField(
                 name: securityKeyStr,
                 obscureText: !_showSecurityKey,
+                keyboardType: TextInputType.visiblePassword,
+                enableSuggestions: false,
                 autocorrect: false,
                 autofocus: true,
 
@@ -151,6 +153,8 @@ class _EncKeyInputFormState extends State<EncKeyInputForm> {
                 child: FormBuilderTextField(
                   name: securityKeyStrReType,
                   obscureText: !_showRetypedSecurityKey,
+                  keyboardType: TextInputType.visiblePassword,
+                  enableSuggestions: false,
                   autocorrect: false,
                   textInputAction: TextInputAction.done,
                   onSubmitted: (_) => widget.onSubmit?.call(),

--- a/lib/src/widgets/secret_text_field.dart
+++ b/lib/src/widgets/secret_text_field.dart
@@ -106,6 +106,11 @@ class _SecretTextFieldState extends State<SecretTextField> {
     return FormBuilderTextField(
       name: widget.fieldKey,
       obscureText: !_showSecret,
+      // Suppress the brief character-reveal that macOS/iOS shows while typing.
+      // TextInputType.visiblePassword disables the input method's character
+      // preview without affecting obscureText behaviour.
+      keyboardType: TextInputType.visiblePassword,
+      enableSuggestions: false,
       autocorrect: false,
       decoration: InputDecoration(
         labelText: widget.fieldLabel.toUpperCase(),

--- a/lib/src/widgets/solid_security_key_cache_dialogs.dart
+++ b/lib/src/widgets/solid_security_key_cache_dialogs.dart
@@ -85,6 +85,9 @@ class SecurityKeyCacheDialogs {
                   TextField(
                     controller: keyController,
                     obscureText: obscureKey,
+                    keyboardType: TextInputType.visiblePassword,
+                    enableSuggestions: false,
+                    autocorrect: false,
                     autofocus: true,
                     textInputAction: TextInputAction.done,
                     onSubmitted: (_) => submitKey(),

--- a/lib/src/widgets/solid_security_key_set_dialog.dart
+++ b/lib/src/widgets/solid_security_key_set_dialog.dart
@@ -208,6 +208,9 @@ class _SetKeyDialogState extends State<SetKeyDialog> {
                   ),
                 ),
                 obscureText: _obscureKey,
+                keyboardType: TextInputType.visiblePassword,
+                enableSuggestions: false,
+                autocorrect: false,
               ),
               const SizedBox(height: 16),
               TextField(
@@ -231,6 +234,9 @@ class _SetKeyDialogState extends State<SetKeyDialog> {
                   ),
                 ),
                 obscureText: _obscureConfirmKey,
+                keyboardType: TextInputType.visiblePassword,
+                enableSuggestions: false,
+                autocorrect: false,
               ),
             ] else ...[
               const SizedBox(height: 20),


### PR DESCRIPTION
## Pull Request Details

### Description
<!--- Describe the problem this PR solves -->
<!--- Describe what you have changed -->
<!--- Describe why this change is required -->

On Apple obscured chars are momentarily displayed. Trying to avoid that.

### Related Issues
<!--- If it fixes an open issue(s), please link to the issue here. -->

#315

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How To Test?
<!--- Describe the tests that a reviewer can undertake to verify your changes. -->

- Update pubspec to point to this branch
- Rebuild the app
- Go to a secret key entry widget

I've test on Linux to ensure still works as expected but not on macOS to see if it fixed the issue.


