### PR TITLE
Amogh/Fix Security Key popup cancellation bug #281

### DIFF
--- a/lib/src/utils/solid_file_operations_download.dart
+++ b/lib/src/utils/solid_file_operations_download.dart
@@ -165,10 +165,12 @@ class SolidFileDownloadOperations {
 
         if (!context.mounted) return;
 
-        await getKeyFromUserIfRequired(
+        if (!await getKeyFromUserIfRequired(
           context,
           const Text('Please enter your security key to download the file'),
-        );
+        )) {
+          return;
+        }
 
         if (!context.mounted) return;
 
@@ -308,10 +310,12 @@ class SolidFileDownloadOperations {
 
       // Get security key if required.
 
-      await getKeyFromUserIfRequired(
+      if (!await getKeyFromUserIfRequired(
         context,
         const Text('Please enter your security key to download the files'),
-      );
+      )) {
+        return;
+      }
 
       if (!context.mounted) return;
 

--- a/lib/src/utils/solid_file_operations_print.dart
+++ b/lib/src/utils/solid_file_operations_print.dart
@@ -419,10 +419,12 @@ class SolidFilePrintOperations {
     try {
       if (!context.mounted) return;
 
-      await getKeyFromUserIfRequired(
+      if (!await getKeyFromUserIfRequired(
         context,
         const Text('Please enter your security key to print the file'),
-      );
+      )) {
+        return;
+      }
 
       if (!context.mounted) return;
 

--- a/lib/src/utils/solid_file_operations_upload.dart
+++ b/lib/src/utils/solid_file_operations_upload.dart
@@ -107,10 +107,12 @@ class SolidFileUploadOperations {
 
         // Ensure the security key is available before writing encrypted data.
 
-        await getKeyFromUserIfRequired(
+        if (!await getKeyFromUserIfRequired(
           context,
           const Text('Please enter your security key to upload the file'),
-        );
+        )) {
+          return;
+        }
 
         if (!context.mounted) return;
 

--- a/lib/src/utils/solid_pod_helpers.dart
+++ b/lib/src/utils/solid_pod_helpers.dart
@@ -113,12 +113,12 @@ Future<bool> loginIfRequired(BuildContext context) async {
 /// Ask for the security key from the user if the security key is not available
 /// or cannot be verfied using the verification key stored in PODs.
 
-Future<void> getKeyFromUserIfRequired(
+Future<bool> getKeyFromUserIfRequired(
   BuildContext context,
   Widget child,
 ) async {
   if (await KeyManager.hasSecurityKey()) {
-    return;
+    return true;
   } else {
     final verificationKey = await KeyManager.getVerificationKey();
     // Get the webId to display in the security key prompt.
@@ -148,13 +148,13 @@ Future<void> getKeyFromUserIfRequired(
       submitFunc: (formDataMap) async {
         await KeyManager.setSecurityKey(formDataMap[inputKey].toString());
         debugPrint('Security key saved');
-        if (context.mounted) Navigator.pop(context);
+        if (context.mounted) Navigator.pop(context, true);
       },
       child: child,
     );
 
     if (context.mounted) {
-      await Navigator.push(
+      final result = await Navigator.push<bool>(
         context,
         MaterialPageRoute(builder: (context) => securityKeyInput),
       );
@@ -163,6 +163,9 @@ Future<void> getKeyFromUserIfRequired(
       // changed after the user submitted (or dismissed) the key prompt.
 
       await securityKeyNotifier.refreshStatus();
+
+      return result ?? false;
     }
+    return false;
   }
 }

--- a/lib/src/widgets/security_key_ui.dart
+++ b/lib/src/widgets/security_key_ui.dart
@@ -246,13 +246,7 @@ class _SecurityKeyUIState extends State<SecurityKeyUI> {
                 child: SecurityKeyButtons(
                   canSubmit: _canSubmit,
                   onSubmit: () async => _submit(context),
-                  onCancel: () {
-                    if (widget.displayMode == SecurityKeyDisplayMode.dialog) {
-                      Navigator.pop(context);
-                    } else {
-                      pushReplacement(context, widget.child);
-                    }
-                  },
+                  onCancel: () => Navigator.pop(context, false),
                 ),
               ),
             ],

--- a/lib/src/widgets/solid_login_actions.dart
+++ b/lib/src/widgets/solid_login_actions.dart
@@ -224,7 +224,7 @@ class SolidLoginActions {
     // Ensure the security key has been fetched once logged in.
 
     if (isLoggedIn) {
-      await getKeyFromUserIfRequired(context, childWidget);
+      if (!await getKeyFromUserIfRequired(context, childWidget)) return;
       if (!context.mounted) return;
     }
 

--- a/lib/src/widgets/solid_login_auth_handler.dart
+++ b/lib/src/widgets/solid_login_auth_handler.dart
@@ -232,7 +232,7 @@ class SolidLoginAuthHandler {
       }
 
       if (!context.mounted) return false;
-      await getKeyFromUserIfRequired(context, childWidget);
+      if (!await getKeyFromUserIfRequired(context, childWidget)) return false;
       if (!context.mounted) return true;
       await pushReplacement(context, childWidget);
     }
@@ -481,7 +481,7 @@ class SolidLoginAuthHandler {
         }
 
         if (!context.mounted) return false;
-        await getKeyFromUserIfRequired(context, childWidget);
+        if (!await getKeyFromUserIfRequired(context, childWidget)) return false;
         if (!context.mounted) return true;
         await pushReplacement(context, childWidget);
       }


### PR DESCRIPTION
## Pull Request Details

### Description

Fixes the Security Key popup cancellation workflow for Issue #281.

Previously, cancelling the Security Key prompt could still allow navigation to continue into the application or continue file operations, even when the user intended to abort the process. The issue occurred because the fullscreen SecurityKeyUI used `pushReplacement` during cancellation and the calling flows did not properly await or validate cancellation results.

This PR updates the authentication and file operation flows to correctly stop execution when the Security Key popup is cancelled.

Key updates include:

* Updated `SecurityKeyUI` cancel behavior to use `Navigator.pop(context, false)`
* Modified `getKeyFromUserIfRequired()` to return `Future<bool>`
* Added cancellation handling in:

  * `SolidLoginAuthHandler`
  * `SolidLoginActions`
  * file upload/download/print operations
* Prevented continuation of workflows after user cancellation
* Fixed lint issues related to flow control braces
* Verified no unrelated formatting or feature changes are included

Modified files:

* `lib/src/widgets/security_key_ui.dart`
* `lib/src/utils/solid_pod_helpers.dart`
* `lib/src/widgets/solid_login_auth_handler.dart`
* `lib/src/widgets/solid_login_actions.dart`
* `lib/src/utils/solid_file_operations_upload.dart`
* `lib/src/utils/solid_file_operations_download.dart`
* `lib/src/utils/solid_file_operations_print.dart`

### Related Issues

Fixes #281

### Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

### How To Test?

1. Run:

```bash
flutter pub get
flutter run
```

2. Trigger any workflow requiring the Security Key popup:

* Login flow
* Upload file
* Download file
* Print file

3. Click "Cancel" on the Security Key popup.

4. Verify:

* The popup closes correctly
* Navigation does not continue
* File operations are aborted cleanly
* No unintended transition to the main application occurs

5. Run validation:

```bash
flutter analyze
dart format .
make prep
make qtest
```

### Checklist

* [ ] Screenshots included here/in linked issue #
* [x] Changes adhere to the style and coding guidelines
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] Any dependent changes have been merged and published in downstream modules
* [x] The update contains no confidential information
* [x] The update has no duplicated content
* [x] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
* [ ] Integration test `dart test` output or screenshot included in issue #
* [ ] I tested the PR on these devices:

  * [ ] Android
  * [ ] iOS
  * [x] Linux
  * [ ] MacOS
  * [ ] Windows
  * [ ] Web
* [ ] I have identified reviewers
* [ ] The PR has been approved by reviewers

### Finalising

* [x] Merge dev into this branch
* [x] Resolve any conflicts
* [ ] Add a one line summary into the CHANGELOG.md
* [x] Push to the git repository and review
* [ ] Merge the PR into dev
