### PR TITLE
Amogh/fix: handle PlatformException(KeyringLocked) in login and auto-login …

### DIFF
--- a/lib/src/widgets/solid_login.dart
+++ b/lib/src/widgets/solid_login.dart
@@ -32,6 +32,7 @@ library;
 // ignore_for_file: public_member_api_docs
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'package:markdown_tooltip/markdown_tooltip.dart';
 import 'package:solidpod/solidpod.dart'
@@ -340,7 +341,25 @@ class _SolidLoginState extends State<SolidLogin> with WidgetsBindingObserver {
 
     if (mounted) setState(() => _checkingAutoLogin = true);
 
-    final session = await tryRestoreSession();
+    // tryRestoreSession() reads from secure storage (libsecret / GNOME keyring
+    // on Linux). If the keyring is locked it throws a PlatformException. Catch
+    // it here so the user sees a clear explanation instead of a blank loading
+    // screen or a silent crash.
+    final session;
+    try {
+      session = await tryRestoreSession();
+    } catch (e) {
+      debugPrint('_checkAutoLogin: tryRestoreSession failed: $e');
+      if (mounted) {
+        setState(() => _checkingAutoLogin = false);
+        // Only show the dialog for secure-storage errors; other exceptions
+        // (e.g. network issues during token refresh) fall through gracefully.
+        if (e is PlatformException) {
+          await SolidLoginActions.showSecureStorageError(context, e);
+        }
+      }
+      return;
+    }
 
     if (!mounted) return;
     if (session == null) {

--- a/lib/src/widgets/solid_login_actions.dart
+++ b/lib/src/widgets/solid_login_actions.dart
@@ -70,8 +70,11 @@ class SolidLoginActions {
   /// not be accessed. Detects the common Linux "KeyringLocked" case and
   /// offers the fix; otherwise shows the raw error so the user isn't left
   /// wondering why login silently failed.
+  ///
+  /// Public so that [SolidLogin] can call this from the auto-login path when
+  /// [tryRestoreSession] throws a [PlatformException].
 
-  static Future<void> _showSecureStorageError(
+  static Future<void> showSecureStorageError(
     BuildContext context,
     Object error,
   ) {
@@ -167,7 +170,7 @@ class SolidLoginActions {
       alreadyLoggedIn = await isUserLoggedIn();
     } catch (e) {
       if (context.mounted) {
-        await _showSecureStorageError(context, e);
+        await showSecureStorageError(context, e);
       }
       return;
     }
@@ -178,7 +181,7 @@ class SolidLoginActions {
         cachedWebId = await getWebId();
       } catch (e) {
         if (context.mounted) {
-          await _showSecureStorageError(context, e);
+          await showSecureStorageError(context, e);
         }
         return;
       }
@@ -246,7 +249,7 @@ class SolidLoginActions {
       isLoggedIn = await isUserLoggedIn();
     } catch (e) {
       if (context.mounted) {
-        await _showSecureStorageError(context, e);
+        await showSecureStorageError(context, e);
       }
       return;
     }

--- a/lib/src/widgets/solid_login_auth_handler.dart
+++ b/lib/src/widgets/solid_login_auth_handler.dart
@@ -273,9 +273,23 @@ class SolidLoginAuthHandler {
 
     if (isDialogCanceled()) return false;
 
-    // Check if user is already logged in before attempting authentication.
-
-    final wasAlreadyLoggedIn = await isUserLoggedIn();
+    // isUserLoggedIn() reads from secure storage (libsecret / GNOME keyring on
+    // Linux). Catch PlatformException here so a locked keyring produces a clear
+    // user-facing message rather than an unhandled exception.
+    final bool wasAlreadyLoggedIn;
+    try {
+      wasAlreadyLoggedIn = await isUserLoggedIn();
+    } catch (e) {
+      debugPrint('handleLogin: isUserLoggedIn() failed: $e');
+      if (context.mounted) {
+        showSnackbar(
+          'Cannot access secure storage. '
+          'If your system keyring is locked, please unlock it and try again.',
+          duration: const Duration(seconds: 6),
+        );
+      }
+      return false;
+    }
 
     if (!context.mounted) return false;
 


### PR DESCRIPTION
### Summary
On Linux, when the system GNOME keyring is locked, `flutter_secure_storage` throws a `PlatformException(KeyringLocked, KeyringLocked, null, null)`. This caused the login button to silently do nothing or the auto-login startup sequence to leave the user stuck on an infinite blank loading screen. 

This PR wraps the vulnerable secure storage check endpoints in try-catches and exposes a user-friendly dialogue helper to instruct the user on how to resolve GNOME keyring issues on Linux.

### Key Changes
- **`solid_login_actions.dart`**: Made `_showSecureStorageError` public as `showSecureStorageError` so it can be reused across other file scopes.
- **`solid_login.dart`**: Wrapped `tryRestoreSession()` in `_checkAutoLogin()` with a `try-catch`. When a secure storage `PlatformException` is caught, it cancels the infinite loading screen spinner (`_checkingAutoLogin = false`) and triggers the secure storage error dialog explaining how to unlock or install the keyring.
- **`solid_login_auth_handler.dart`**: Wrapped the pre-authentication `isUserLoggedIn()` check inside `handleLogin()` with a `try-catch`. On error, it displays a themed snackbar instructing the user to unlock the keyring and returns cleanly instead of propagating an unhandled crash up the stack.

### Verification
- Tested to ensure normal login and continue buttons operate as expected when no keyring exceptions occur.
- Verified that PlatformExceptions from secure storage no longer cause silent UI freezes.

Closes #350
