### PR TITLE
Fix bug when autologin but no domain folder.

### DIFF
--- a/lib/src/utils/solid_pod_helpers.dart
+++ b/lib/src/utils/solid_pod_helpers.dart
@@ -33,10 +33,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:solidpod/solidpod.dart'
     show
+        checkResourceStatus,
         getEncKeyPath,
+        getFileUrl,
         getWebId,
         isUserLoggedIn,
         KeyManager,
+        ResourceStatus,
         SecurityKeyVerificationException;
 
 import 'package:solidui/src/constants/ui.dart' show SecurityStrings;
@@ -135,6 +138,49 @@ Future<void> getKeyFromUserIfRequired(
   if (await KeyManager.hasSecurityKey()) {
     return;
   } else {
+    // 20260728 gjw Before prompting, confirm the POD actually holds a
+    // keyset to verify against. If the app's encryption key file is
+    // missing on the server (e.g. the app folder was removed or moved
+    // aside), no key the user enters can ever verify, so prompting would
+    // trap them in an "Incorrect Security Key" loop. Direct them to
+    // re-run the setup instead. If the existence check itself fails
+    // (e.g. offline), fall through to the normal prompt rather than
+    // blocking the user.
+
+    try {
+      final encKeyUrl = await getFileUrl(await getEncKeyPath());
+      final status = await checkResourceStatus(encKeyUrl);
+      if (status != ResourceStatus.exist) {
+        debugPrint(
+          'getKeyFromUserIfRequired: no keyset found on the server '
+          '($encKeyUrl: $status) — skipping the security key prompt.',
+        );
+        if (context.mounted) {
+          await showDialog<void>(
+            context: context,
+            builder: (ctx) => AlertDialog(
+              title: const Text('POD Not Initialised'),
+              content: const Text(
+                'Your POD does not appear to be initialised for this app '
+                '— its encryption keys were not found on the server.\n\n'
+                'Please log out and log in again to run the setup and '
+                're-initialise your POD.',
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(ctx).pop(),
+                  child: const Text('OK'),
+                ),
+              ],
+            ),
+          );
+        }
+        return;
+      }
+    } on Object catch (e) {
+      debugPrint('getKeyFromUserIfRequired: keyset check failed: $e');
+    }
+
     // Get the webId to display in the security key prompt.
 
     final webId = await getWebId();

--- a/lib/src/widgets/solid_login.dart
+++ b/lib/src/widgets/solid_login.dart
@@ -366,9 +366,47 @@ class _SolidLoginState extends State<SolidLogin> with WidgetsBindingObserver {
       return;
     }
 
-    // Session restored — navigate directly to the child widget.
-    await Navigator.of(context).pushReplacement(
-      MaterialPageRoute<void>(builder: (_) => widget.child),
+    // 20260728 gjw Session restored. Previously we navigated straight to
+    // the child widget here, which skipped the remote POD structure
+    // verification that both the LOGIN and CONTINUE paths perform. If the
+    // app's folder had been removed on the server (e.g. moved aside as a
+    // backup), the app would proceed into a broken environment and prompt
+    // for a security key that can no longer be verified against the
+    // (missing) keyset. Route through the same CONTINUE flow instead so
+    // the structure is verified and, when incomplete, the user is signed
+    // out with a message to log in again (which re-runs the setup wizard
+    // to re-initialise the POD).
+
+    // The default structure lists are populated asynchronously by
+    // _initPackageInfo() and may not be ready yet in this post-frame
+    // callback; performContinue() skips verification when the folder list
+    // is empty, so ensure they are populated before the check.
+
+    if (defaultFolders.isEmpty) {
+      await setAppDirName(widget.appDirectory);
+      final folders = await generateDefaultFolders();
+      final files = await generateDefaultFiles();
+      final customFolders = generateCustomFolders(
+        widget.customFolderPathList,
+      );
+      if (!mounted) return;
+      setState(() {
+        defaultFolders = folders + customFolders;
+        defaultFiles = files;
+      });
+    }
+
+    if (!mounted) return;
+    setState(() => _checkingAutoLogin = false);
+
+    await SolidLoginActions.performContinue(
+      context: context,
+      childWidget: widget.child,
+      defaultFolders: defaultFolders,
+      defaultFiles: defaultFiles,
+      updateDialogCanceledState: updateState,
+      showSnackbar: _showSnackbar,
+      staySignedIn: _staySignedIn,
     );
   }
 


### PR DESCRIPTION
## Pull Request Details

### Description
<!--- Describe the problem this PR solves -->
<!--- Describe what you have changed -->
<!--- Describe why this change is required -->

Fixed a bug when server domain folder for the app has disappeared and autologin attempts and asks for secret key.

Two fixes in solidui (dated comments, 20260728):

1.   _checkAutoLogin now routes a restored session through SolidLoginActions.performContinue — identical semantics to pressing CONTINUE: structure verified; missing → silent logout + snackbar telling you to log in again (which runs the wizard and re-creates the folder with fresh keys); intact → key prompt if needed, then into the app. It also populates defaultFolders/defaultFiles first if _initPackageInfo() hasn't finished, since performContinue skips verification on an empty folder list — a latent race in the post-frame callback.
 
2.   Backstop in getKeyFromUserIfRequired: before prompting, it checks the server actually has enc-keys.ttl; if not, it shows a "POD Not Initialised — log out and log in again to run setup" dialog instead of trapping you in an Incorrect-Security-Key loop. If the existence check itself fails (offline), it falls through to the normal prompt.

### Related Issues
<!--- If it fixes an open issue(s), please link to the issue here. -->

#389 

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How To Test?
<!--- Describe the tests that a reviewer can undertake to verify your changes. -->

+ Delete the app's domain folder on the server (move the folder asside on the server or archive using MyPod)
+ Start up the app to get the Security Key Popup

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] Screenshots included here/in linked issue #
- [X] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [X] I have performed a self-review of the code
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] The update contains no confidential information
- [X] The update has no duplicated content
- [X] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [X] Integration test `dart test` output or screenshot included in issue #
- [X] I tested the PR on these devices:
  - [ ] Android
  - [ ] iOS
  - [X] Linux
  - [ ] MacOS
  - [ ] Windows
  - [ ] Web
- [X] I have identified reviewers
- [ ] The PR has been approved by reviewers

### Finalising
<!--- Once PR discussion is complete and reviewers have approved. -->

- [ ] Merge dev into the this branch
- [ ] Resolve any conflicts
- [ ] Add a one line summary into the CHANGELOG.md
- [ ] Push to the git repository and review
- [ ] Merge the PR into dev
